### PR TITLE
fix: Ensure PMS 9 compliance

### DIFF
--- a/src/cpn.rs
+++ b/src/cpn.rs
@@ -90,12 +90,15 @@ impl FromStr for Cpn {
 // Winnow parsers
 
 /// Parse category name
-/// PMS: category name must start with letter/digit, contain alphanumeric + _ - +
+/// PMS 3.1.1: category name may contain [A-Za-z0-9+_.-], must not begin with hyphen or plus
 pub(crate) fn parse_category<'s>() -> impl Parser<&'s str, String, ErrMode<ContextError>> {
     take_while(1.., |c: char| {
-        c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '+'
+        c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '+' || c == '.'
     })
-    .verify(|s: &str| s.chars().next().is_some_and(|c| c.is_ascii_alphanumeric()) && s.len() <= 64)
+    .verify(|s: &str| {
+        let first_char = s.chars().next().unwrap();
+        !matches!(first_char, '-' | '.' | '+')
+    })
     .map(|s: &str| s.to_string())
     .context(StrContext::Label("category"))
 }
@@ -107,7 +110,10 @@ pub(crate) fn parse_package<'s>() -> impl Parser<&'s str, String, ErrMode<Contex
     take_while(1.., |c: char| {
         c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '+'
     })
-    .verify(|s: &str| s.chars().next().is_some_and(|c| c.is_ascii_alphanumeric()) && s.len() <= 64)
+    .verify(|s: &str| {
+        // Must start with alphanumeric
+        s.chars().next().is_some_and(|c| c.is_ascii_alphanumeric())
+    })
     .map(|s: &str| s.to_string())
     .context(StrContext::Label("package"))
 }
@@ -122,6 +128,7 @@ pub(crate) fn parse_cpn<'s>() -> impl Parser<&'s str, Cpn, ErrMode<ContextError>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::Cpv;
 
     #[test]
     fn test_cpn_parsing() {
@@ -146,5 +153,64 @@ mod tests {
         assert!(Cpn::parse("invalid").is_err());
         assert!(Cpn::parse("/package").is_err());
         assert!(Cpn::parse("category/").is_err());
+    }
+
+    #[test]
+    fn test_package_name_cannot_end_with_hyphen_version() {
+        // PMS 3.1.2: "must not end in a hyphen followed by anything matching the version syntax"
+        // Note: This rule is enforced at the CPV level, not the CPN level.
+        // The CPN parser allows hyphen endings, but the CPV parser ensures proper version boundary detection.
+
+        // These are valid CPN names (the CPV parser will handle version detection)
+        assert!(
+            Cpn::parse("cat/pkg-").is_ok(),
+            "Package name ending with hyphen is valid at CPN level"
+        );
+        assert!(
+            Cpn::parse("cat/pkg-test").is_ok(),
+            "Package name ending with hyphen+word should be valid"
+        );
+
+        // But when used in CPV context, the version boundary detection should work correctly
+        let cpv1 = Cpv::parse("cat/pkg--1.2"); // pkg- is package, -1.2 is version
+        assert!(
+            cpv1.is_ok(),
+            "CPV parser should handle hyphen in package name correctly"
+        );
+        let cpv1 = cpv1.unwrap();
+        assert_eq!(cpv1.package(), "pkg-");
+        assert_eq!(cpv1.version.numbers, vec![1, 2]);
+    }
+
+    #[test]
+    fn test_package_name_no_arbitrary_length_limit() {
+        // PMS doesn't specify length limits, so we shouldn't impose arbitrary ones
+
+        // Valid: normal length
+        assert!(Cpn::parse("cat/normal-package-name").is_ok());
+
+        // Valid: very long name (PMS doesn't specify limits)
+        let long_name = "a".repeat(100);
+        assert!(Cpn::parse(&format!("cat/{}", long_name)).is_ok());
+
+        // Valid: very long category (PMS doesn't specify limits)
+        let long_cat = "a".repeat(100);
+        assert!(Cpn::parse(&format!("{}/package", long_cat)).is_ok());
+    }
+
+    #[test]
+    fn test_category_name_with_dot() {
+        // PMS 3.1.1: category names may contain dots
+        assert!(Cpn::parse("dev.lang/rust").is_ok());
+        assert!(Cpn::parse("app-office/libreoffice").is_ok());
+        assert!(Cpn::parse("media.gfx/gimp").is_ok());
+
+        // Category names can start with underscore (allowed character)
+        assert!(Cpn::parse("_special/package").is_ok());
+
+        // But category names must not begin with hyphen, dot, or plus
+        assert!(Cpn::parse("-dev-lang/rust").is_err());
+        assert!(Cpn::parse(".dev-lang/rust").is_err());
+        assert!(Cpn::parse("+dev-lang/rust").is_err());
     }
 }

--- a/src/dep.rs
+++ b/src/dep.rs
@@ -240,6 +240,8 @@ pub(crate) fn parse_dep<'s>() -> impl Parser<&'s str, Dep, ErrMode<ContextError>
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::slot::SlotOperator;
+    use crate::version::{Operator, SuffixKind};
 
     #[test]
     fn test_dep_simple() {
@@ -302,6 +304,40 @@ mod tests {
         assert!(dep.version.is_some());
         assert!(dep.slot_dep.is_some());
         assert!(dep.use_deps.is_some());
+        assert_eq!(dep.repo, Some("gentoo".to_string()));
+    }
+
+    #[test]
+    fn test_dep_with_all_features() {
+        // Test a complex dependency using all PMS features
+        let dep_str = "!!>=dev-lang/rust-1.75.0_rc1:0/1.75=[ssl(-),-debug,python?]::gentoo";
+        let dep = Dep::parse(dep_str).unwrap();
+
+        assert_eq!(dep.blocker, Some(Blocker::Strong));
+        assert!(dep.version.is_some());
+        let version = dep.version.as_ref().unwrap();
+        assert_eq!(version.op, Some(Operator::GreaterOrEqual));
+        assert_eq!(version.numbers[0], 1);
+        assert_eq!(version.suffixes[0].kind, SuffixKind::Rc);
+
+        assert!(dep.slot_dep.is_some());
+        let slot_dep = dep.slot_dep.as_ref().unwrap();
+        match slot_dep {
+            SlotDep::Slot {
+                slot: Some(s),
+                op: Some(o),
+            } => {
+                assert_eq!(s.slot, "0");
+                assert_eq!(s.subslot, Some("1.75".to_string()));
+                assert_eq!(*o, SlotOperator::Equal);
+            }
+            _ => panic!("Unexpected slot dep format"),
+        }
+
+        assert!(dep.use_deps.is_some());
+        let use_deps = dep.use_deps.as_ref().unwrap();
+        assert_eq!(use_deps.len(), 3);
+
         assert_eq!(dep.repo, Some("gentoo".to_string()));
     }
 }

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -126,9 +126,14 @@ impl FromStr for SlotDep {
 // Winnow parsers
 
 /// Parse slot name (alphanumeric, _, -, +, .)
+/// PMS 3.1.3: must not begin with hyphen, dot, or plus
 fn parse_slot_name<'s>() -> impl Parser<&'s str, String, ErrMode<ContextError>> {
     take_while(1.., |c: char| {
         c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '+' || c == '.'
+    })
+    .verify(|s: &str| {
+        let first_char = s.chars().next().unwrap();
+        !matches!(first_char, '-' | '.' | '+')
     })
     .map(|s: &str| s.to_string())
 }
@@ -213,5 +218,22 @@ mod tests {
             }
             _ => panic!("unexpected slot dep"),
         }
+    }
+
+    #[test]
+    fn test_slot_name_validation() {
+        // PMS 3.1.3: "A slot name may contain any of the characters [A-Za-z0-9+_.-].
+        // It must not begin with a hyphen, a dot or a plus sign."
+
+        // Valid slot names
+        assert!(SlotDep::parse("0").is_ok());
+        assert!(SlotDep::parse("3.12").is_ok());
+        assert!(SlotDep::parse("stable").is_ok());
+        assert!(SlotDep::parse("slot+name").is_ok());
+
+        // Invalid: starts with forbidden characters
+        assert!(SlotDep::parse("-slot").is_err());
+        assert!(SlotDep::parse(".slot").is_err());
+        assert!(SlotDep::parse("+slot").is_err());
     }
 }

--- a/src/use_dep.rs
+++ b/src/use_dep.rs
@@ -158,10 +158,12 @@ impl FromStr for UseDep {
 // Winnow parsers
 
 /// Parse USE flag name
+/// PMS 3.1.4: must begin with alphanumeric character
 fn parse_use_flag<'s>() -> impl Parser<&'s str, String, ErrMode<ContextError>> {
     take_while(1.., |c: char| {
         c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '+' || c == '@'
     })
+    .verify(|s: &str| s.chars().next().is_some_and(|c| c.is_ascii_alphanumeric()))
     .map(|s: &str| s.to_string())
 }
 
@@ -322,5 +324,23 @@ mod tests {
         assert_eq!(deps.len(), 1);
         assert_eq!(deps[0].flag, "introspection");
         assert_eq!(deps[0].kind, UseDepKind::Conditional);
+    }
+
+    #[test]
+    fn test_use_flag_name_validation() {
+        // PMS 3.1.4: "A USE flag name may contain any of the characters [A-Za-z0-9+_@-].
+        // It must begin with an alphanumeric character."
+
+        // Valid flag names
+        assert!(UseDep::parse("ssl").is_ok());
+        assert!(UseDep::parse("python_targets_python3_12").is_ok());
+        assert!(UseDep::parse("unicode+").is_ok());
+        assert!(UseDep::parse("icu@").is_ok());
+        assert!(UseDep::parse("-flag").is_ok()); // -flag is valid: flag starts with 'f' (alphanumeric)
+
+        // Invalid: flag name itself starts with non-alphanumeric
+        assert!(UseDep::parse("@flag").is_err()); // @flag is invalid: flag starts with '@'
+        assert!(UseDep::parse("-\u{40}flag").is_err()); // -@flag is invalid: flag starts with '@'
+        assert!(UseDep::parse("-_flag").is_err()); // -_flag is invalid: flag starts with '_'
     }
 }

--- a/src/version.rs
+++ b/src/version.rs
@@ -530,4 +530,61 @@ mod tests {
         assert!(version.glob);
         assert_eq!(version.numbers, vec![1, 2, 3]);
     }
+
+    #[test]
+    fn test_version_glob_matching() {
+        // PMS 8.3.1: "if the version specified has an asterisk immediately following it,
+        // then only the given number of version components is used for comparison"
+
+        let glob_version = Version::parse("1.2.3*").unwrap();
+        assert!(glob_version.glob);
+
+        // Should match versions that start with 1.2.3
+        let v1 = Version::parse("1.2.3").unwrap();
+        let v2 = Version::parse("1.2.3.4").unwrap();
+        let v3 = Version::parse("1.2.3.4.5").unwrap();
+
+        // All should match the glob pattern
+        assert_eq!(glob_version.glob_cmp(&v1), std::cmp::Ordering::Equal);
+        assert_eq!(glob_version.glob_cmp(&v2), std::cmp::Ordering::Equal);
+        assert_eq!(glob_version.glob_cmp(&v3), std::cmp::Ordering::Equal);
+
+        // Should not match versions that don't start with 1.2.3
+        let v4 = Version::parse("1.2.4").unwrap();
+        assert_ne!(glob_version.glob_cmp(&v4), std::cmp::Ordering::Equal);
+    }
+
+    #[test]
+    fn test_version_with_letter_glob() {
+        // Test glob matching with letter suffix
+        let glob_version = Version::parse("1.2a*").unwrap();
+        assert!(glob_version.glob);
+
+        let v1 = Version::parse("1.2a").unwrap();
+        let v2 = Version::parse("1.2a_beta1").unwrap();
+
+        // Should match
+        assert_eq!(glob_version.glob_cmp(&v1), std::cmp::Ordering::Equal);
+        assert_eq!(glob_version.glob_cmp(&v2), std::cmp::Ordering::Equal);
+
+        // Should not match different letter
+        let v3 = Version::parse("1.2b").unwrap();
+        assert_ne!(glob_version.glob_cmp(&v3), std::cmp::Ordering::Equal);
+    }
+
+    #[test]
+    fn test_version_component_count() {
+        // PMS: "The package manager must neither impose fixed limits upon the number
+        // of version components, nor upon the length of any component."
+
+        // Test many components
+        let many_components = "1.2.3.4.5.6.7.8.9.10.11.12.13.14.15";
+        let version = Version::parse(many_components).unwrap();
+        assert_eq!(version.numbers.len(), 15);
+
+        // Test long component values
+        let long_component = "12345678901234567890"; // 20 digits
+        let version = Version::parse(long_component).unwrap();
+        assert_eq!(version.numbers[0], 12345678901234567890u64);
+    }
 }


### PR DESCRIPTION
- Add dot (.) to category name allowed characters (PMS 3.1.1)
- Enforce category names cannot begin with hyphen, dot, or plus (PMS 3.1.1)
- Remove redundant is_ascii_alphanumeric() check that rejected valid underscores
- Add comprehensive tests for category name validation
- Remove arbitrary 64-character length limits not specified in PMS
- Fix USE flag and slot name validation to match PMS specifications

Generated by Mistral Vibe.