### PR TITLE
refactor: Extract reusable character set parsers

### DIFF
--- a/src/cpn.rs
+++ b/src/cpn.rs
@@ -5,7 +5,6 @@ use std::str::FromStr;
 use winnow::combinator::cut_err;
 use winnow::error::{ContextError, ErrMode, StrContext};
 use winnow::prelude::*;
-use winnow::token::take_while;
 
 use crate::error::{Error, Result};
 
@@ -92,30 +91,30 @@ impl FromStr for Cpn {
 /// Parse category name
 /// PMS 3.1.1: category name may contain [A-Za-z0-9+_.-], must not begin with hyphen or plus
 pub(crate) fn parse_category<'s>() -> impl Parser<&'s str, String, ErrMode<ContextError>> {
-    take_while(1.., |c: char| {
-        c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '+' || c == '.'
-    })
-    .verify(|s: &str| {
-        let first_char = s.chars().next().unwrap();
-        !matches!(first_char, '-' | '.' | '+')
-    })
-    .map(|s: &str| s.to_string())
-    .context(StrContext::Label("category"))
+    use crate::parsers::parse_ident_with_dot;
+
+    parse_ident_with_dot()
+        .verify(|s: &str| {
+            let first_char = s.chars().next().unwrap();
+            !matches!(first_char, '-' | '.' | '+')
+        })
+        .map(|s: &str| s.to_string())
+        .context(StrContext::Label("category"))
 }
 
 /// Parse package name
 /// PMS: package name must start with letter/digit, contain alphanumeric + _ - +
 /// Must not end with hyphen followed by version-like string
 pub(crate) fn parse_package<'s>() -> impl Parser<&'s str, String, ErrMode<ContextError>> {
-    take_while(1.., |c: char| {
-        c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '+'
-    })
-    .verify(|s: &str| {
-        // Must start with alphanumeric
-        s.chars().next().is_some_and(|c| c.is_ascii_alphanumeric())
-    })
-    .map(|s: &str| s.to_string())
-    .context(StrContext::Label("package"))
+    use crate::parsers::parse_ident_base;
+
+    parse_ident_base()
+        .verify(|s: &str| {
+            // Must start with alphanumeric
+            s.chars().next().is_some_and(|c| c.is_ascii_alphanumeric())
+        })
+        .map(|s: &str| s.to_string())
+        .context(StrContext::Label("package"))
 }
 
 /// Parse full Cpn (category/package)

--- a/src/cpv.rs
+++ b/src/cpv.rs
@@ -5,10 +5,10 @@ use std::str::FromStr;
 use winnow::combinator::cut_err;
 use winnow::error::{ContextError, ErrMode, StrContext};
 use winnow::prelude::*;
-use winnow::token::take_while;
 
 use crate::cpn::{parse_category, parse_package, Cpn};
 use crate::error::{Error, Result};
+use crate::parsers::parse_ident_with_dot_star;
 use crate::version::{parse_version, Version};
 
 /// Category/Package/Version (Cpv)
@@ -106,13 +106,7 @@ impl FromStr for Cpv {
 /// Package names can contain hyphens, so we need to find the version boundary
 /// Per PMS, version always starts after the LAST hyphen followed by a digit
 pub(crate) fn parse_cpv<'s>() -> impl Parser<&'s str, Cpv, ErrMode<ContextError>> {
-    (
-        parse_category(),
-        '/',
-        cut_err(take_while(1.., |c: char| {
-            c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '+' || c == '.' || c == '*'
-        })),
-    )
+    (parse_category(), '/', cut_err(parse_ident_with_dot_star()))
         .verify_map(|(category, _, pkg_ver): (String, char, &str)| {
             // Find the last -<digit> boundary to split package from version
             let bytes = pkg_ver.as_bytes();

--- a/src/dep.rs
+++ b/src/dep.rs
@@ -4,7 +4,6 @@ use std::str::FromStr;
 use winnow::combinator::{alt, cut_err, opt, preceded};
 use winnow::error::{ContextError, ErrMode, StrContext};
 use winnow::prelude::*;
-use winnow::token::take_while;
 
 use crate::cpn::{parse_cpn, Cpn};
 use crate::cpv::{parse_cpv, Cpv};
@@ -175,10 +174,9 @@ fn parse_blocker<'s>() -> impl Parser<&'s str, Blocker, ErrMode<ContextError>> {
 
 /// Parse repository name (alphanumeric, _, -, +)
 fn parse_repo<'s>() -> impl Parser<&'s str, String, ErrMode<ContextError>> {
-    take_while(1.., |c: char| {
-        c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '+'
-    })
-    .map(|s: &str| s.to_string())
+    use crate::parsers::parse_ident_base;
+
+    parse_ident_base().map(|s: &str| s.to_string())
 }
 
 /// Parse full dependency atom

--- a/src/dep_entry.rs
+++ b/src/dep_entry.rs
@@ -4,10 +4,11 @@ use winnow::ascii::multispace0;
 use winnow::combinator::{alt, cut_err, delimited, dispatch, opt, peek, preceded, repeat};
 use winnow::error::{ContextError, ErrMode, StrContext};
 use winnow::prelude::*;
-use winnow::token::{any, take_while};
+use winnow::token::any;
 
 use crate::dep::{parse_dep, Dep};
 use crate::error::{Error, Result};
+use crate::parsers::parse_ident_base;
 
 /// Structured dependency tree entry.
 ///
@@ -212,11 +213,9 @@ fn parse_at_most_one_of(input: &mut &str) -> ModalResult<DepEntry> {
 /// commits so a missing `( ... )` is a hard error.
 fn parse_use_conditional(input: &mut &str) -> ModalResult<DepEntry> {
     let negate = opt('!').parse_next(input)?.is_some();
-    let flag: String = take_while(1.., |c: char| {
-        c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '+'
-    })
-    .map(|s: &str| s.to_string())
-    .parse_next(input)?;
+    let flag: String = parse_ident_base()
+        .map(|s: &str| s.to_string())
+        .parse_next(input)?;
     '?'.parse_next(input)?;
     // After '?', committed to USE conditional
     multispace0.parse_next(input)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,7 @@ mod cpv;
 mod dep;
 mod dep_entry;
 mod error;
+mod parsers;
 mod slot;
 mod use_dep;
 mod version;

--- a/src/parsers.rs
+++ b/src/parsers.rs
@@ -1,0 +1,78 @@
+use winnow::error::{ContextError, ErrMode};
+use winnow::prelude::*;
+use winnow::token::take_while;
+
+/// Parse alphanumeric + common special characters
+/// Base set: [A-Za-z0-9+_-]
+pub(crate) fn parse_ident_base<'s>() -> impl Parser<&'s str, &'s str, ErrMode<ContextError>> {
+    take_while(1.., |c: char| {
+        c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '+'
+    })
+}
+
+/// Parse alphanumeric + common special characters + dot
+/// Set: [A-Za-z0-9+_.-]
+pub(crate) fn parse_ident_with_dot<'s>() -> impl Parser<&'s str, &'s str, ErrMode<ContextError>> {
+    take_while(1.., |c: char| {
+        c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '+' || c == '.'
+    })
+}
+
+/// Parse alphanumeric + common special characters + @
+/// Set: [A-Za-z0-9+_@-]
+pub(crate) fn parse_ident_with_at<'s>() -> impl Parser<&'s str, &'s str, ErrMode<ContextError>> {
+    take_while(1.., |c: char| {
+        c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '+' || c == '@'
+    })
+}
+
+/// Parse alphanumeric + common special characters + . and *
+/// Set: [A-Za-z0-9+_.*-]
+pub(crate) fn parse_ident_with_dot_star<'s>() -> impl Parser<&'s str, &'s str, ErrMode<ContextError>>
+{
+    take_while(1.., |c: char| {
+        c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '+' || c == '.' || c == '*'
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_parse_ident_base() {
+        assert_eq!(parse_ident_base().parse("hello"), Ok("hello"));
+        assert_eq!(parse_ident_base().parse("hello-world"), Ok("hello-world"));
+        assert_eq!(parse_ident_base().parse("hello_world"), Ok("hello_world"));
+        assert_eq!(parse_ident_base().parse("hello+world"), Ok("hello+world"));
+        assert!(parse_ident_base().parse("").is_err());
+        // Note: single "-" is technically valid for the base parser (no validation)
+        // The validation happens in the specific parsers that use this
+        assert_eq!(parse_ident_base().parse("-"), Ok("-"));
+    }
+
+    #[test]
+    fn test_parse_ident_with_dot() {
+        assert_eq!(
+            parse_ident_with_dot().parse("hello.world"),
+            Ok("hello.world")
+        );
+        assert_eq!(parse_ident_with_dot().parse("dev.lang"), Ok("dev.lang"));
+        assert!(parse_ident_with_dot().parse(".invalid").is_ok()); // No validation here
+    }
+
+    #[test]
+    fn test_parse_ident_with_at() {
+        assert_eq!(parse_ident_with_at().parse("user@host"), Ok("user@host"));
+        assert_eq!(parse_ident_with_at().parse("flag@"), Ok("flag@"));
+    }
+
+    #[test]
+    fn test_parse_ident_with_dot_star() {
+        assert_eq!(parse_ident_with_dot_star().parse("pkg.*"), Ok("pkg.*"));
+        assert_eq!(
+            parse_ident_with_dot_star().parse("test-1.2*3"),
+            Ok("test-1.2*3")
+        );
+    }
+}

--- a/src/slot.rs
+++ b/src/slot.rs
@@ -4,7 +4,6 @@ use std::str::FromStr;
 use winnow::combinator::{alt, opt, preceded};
 use winnow::error::{ContextError, ErrMode, StrContext};
 use winnow::prelude::*;
-use winnow::token::take_while;
 
 use crate::error::{Error, Result};
 
@@ -128,14 +127,14 @@ impl FromStr for SlotDep {
 /// Parse slot name (alphanumeric, _, -, +, .)
 /// PMS 3.1.3: must not begin with hyphen, dot, or plus
 fn parse_slot_name<'s>() -> impl Parser<&'s str, String, ErrMode<ContextError>> {
-    take_while(1.., |c: char| {
-        c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '+' || c == '.'
-    })
-    .verify(|s: &str| {
-        let first_char = s.chars().next().unwrap();
-        !matches!(first_char, '-' | '.' | '+')
-    })
-    .map(|s: &str| s.to_string())
+    use crate::parsers::parse_ident_with_dot;
+
+    parse_ident_with_dot()
+        .verify(|s: &str| {
+            let first_char = s.chars().next().unwrap();
+            !matches!(first_char, '-' | '.' | '+')
+        })
+        .map(|s: &str| s.to_string())
 }
 
 /// Parse slot with optional subslot

--- a/src/use_dep.rs
+++ b/src/use_dep.rs
@@ -4,7 +4,6 @@ use std::str::FromStr;
 use winnow::combinator::{alt, cut_err, delimited, opt, preceded, separated, terminated};
 use winnow::error::{ContextError, ErrMode, StrContext};
 use winnow::prelude::*;
-use winnow::token::take_while;
 
 use crate::error::{Error, Result};
 
@@ -160,11 +159,11 @@ impl FromStr for UseDep {
 /// Parse USE flag name
 /// PMS 3.1.4: must begin with alphanumeric character
 fn parse_use_flag<'s>() -> impl Parser<&'s str, String, ErrMode<ContextError>> {
-    take_while(1.., |c: char| {
-        c.is_ascii_alphanumeric() || c == '_' || c == '-' || c == '+' || c == '@'
-    })
-    .verify(|s: &str| s.chars().next().is_some_and(|c| c.is_ascii_alphanumeric()))
-    .map(|s: &str| s.to_string())
+    use crate::parsers::parse_ident_with_at;
+
+    parse_ident_with_at()
+        .verify(|s: &str| s.chars().next().is_some_and(|c| c.is_ascii_alphanumeric()))
+        .map(|s: &str| s.to_string())
 }
 
 /// Parse USE default


### PR DESCRIPTION
Create a new parsers module with reusable character set parsers to eliminate duplicate take_while patterns throughout the codebase.

- Add src/parsers.rs with 4 reusable parsers:
  * parse_ident_base() for [A-Za-z0-9+_-]
  * parse_ident_with_dot() for [A-Za-z0-9+_.-]
  * parse_ident_with_at() for [A-Za-z0-9+_@-]
  * parse_ident_with_dot_star() for [A-Za-z0-9+_.*-]

- Refactor 7 parsers to use the new helpers:
  * cpn::parse_category() and cpn::parse_package()
  * dep::parse_repo()
  * use_dep::parse_use_flag()
  * slot::parse_slot_name()
  * dep_entry::USE conditional flag parsing
  * cpv::package+version parsing

- Eliminate ~50 lines of duplicated character set parsing code
- Maintain all existing functionality and test coverage
- All 80 tests pass, examples work correctly

Generated by Mistral Vibe.